### PR TITLE
If lang file doesn't exist use English

### DIFF
--- a/timeago.inc.php
+++ b/timeago.inc.php
@@ -332,7 +332,12 @@ class TimeAgo
     {
         // no time strings loaded? load them and store it all in static variables
         if (self::$timeAgoStrings == null || self::$language != $language) {
-            include(__DIR__ . '/translations/' . $language . '.php');
+            $file = __DIR__ . '/translations/' . $language . '.php';             
+            if (!file_exists($file) {            
+                $file = __DIR__ . '/translations/en.php';                            
+            }
+                
+            include($file);
 
             if (!isset($timeAgoStrings) && $alternate_path) {
                 include($alternate_path);


### PR DESCRIPTION
In order to avoid PHP warning " failed to open stream: No such file or directory" if using another language.