### PR TITLE
TimeZone in constructor should be a string type

### DIFF
--- a/src/Westsworld/TimeAgo.php
+++ b/src/Westsworld/TimeAgo.php
@@ -35,7 +35,7 @@ class TimeAgo
 
     /**
      * TimeAgo constructor.
-     * @param null|DateTimeZone $timezone the timezone to use (uses system if none is given)
+     * @param null|string $timezone the timezone to use (uses system if none is given)
      * @param string $language the language to use (defaults to 'en' for english)
      */
     public function __construct($timezone = null, $language = 'en')

--- a/tests/TimeagoTest.php
+++ b/tests/TimeagoTest.php
@@ -130,4 +130,21 @@ class TimeagoTest extends PHPUnit_Framework_TestCase
         $difference = $timeAgo->dateDifference($past->format('Y-m-d H:i:s'), $now->format('Y-m-d H:i:s'));
         $this->assertEquals(1, $difference['seconds']);
     }
+
+    public function testDateTimeZoneInConstructorThrowsWarning()
+    {
+        $timeAgo = new TimeAgo(new DateTimeZone('UTC'), 'en');
+
+        $this->expectException(PHPUnit_Framework_Error_Warning::class);
+        $this->expectExceptionMessage('expects parameter 1 to be string, object given');
+
+        $this->assertEquals('1 minute ago', $timeAgo->inWords("-30 second"));
+    }
+
+    public function testTimeZoneStringInConstructor()
+    {
+        $timeAgo = new TimeAgo('UTC', 'en');
+
+        $this->assertEquals('1 minute ago', $timeAgo->inWords("-30 second"));
+    }
 }


### PR DESCRIPTION
In TimeAgo::changeTimezone() the php function date_default_timezone_get() is used. However date_default_timezone_get() doesn't support the DateTimeZone object and only accepts a timezone string.