### PR TITLE
Some translation improvments

### DIFF
--- a/translations/ru.php
+++ b/translations/ru.php
@@ -5,11 +5,29 @@ $timeAgoStrings = array(
   'aboutOneHour' => "час назад",
   'aboutOneMonth' => "около месяца назад",
   'aboutOneYear' => "год назад",
-  'days' => "%s дней назад",
-  'hours' => "%s часов назад",
+  'days' => array("%s день назад", "%s дня назад", "%s дней назад"),
+  'hours' => array("%s час назад", "%s часа назад", "%s часов назад"),
   'lessThanAMinute' => "меньше минуты",
-  'lessThanOneHour' => "%s минут назад",
-  'months' => "%s месяцев назад",
+  'lessThanOneHour' => array("%s минуту назад", "%s минуты назад", "%s минут назад"),
+  'months' => array("%s месяцев назад", "%s месяцев назад", "%s месяцев назад"),
   'oneMinute' => "минуту назад",
-  'years' => "больше %s лет назад"
+  'years' => array("больше %s года назад", "больше %s лет назад", "больше %s лет назад")
 );
+
+$pluralFormDetection = function ($num, $collection) {
+  $num = (int) $num;
+
+  if ($num > 20) {
+    $num %= 10;
+  }
+
+  if ($num == 1) {
+    $form = $collection[0];
+  } elseif ($num > 1 && $num < 5) {
+    $form = $collection[1];
+  } else {
+    $form = isset($collection[2]) ? $collection[2] : $collection[1];
+  }
+
+  return $form;
+};


### PR DESCRIPTION
New instance of TimeAgo with another language should not affect already created instances.
All language variables should not be static.

Support for plural form in some languages. Each translation file can provide it's own varaible $pluralFormDetection with function, that will return coresponding plural form.
If now such variable provided, default function will be used.

Add plural form support for "ru" translation