### PR TITLE
Fix issue #72 calculate correctly "isLessThan44Min29Secs"

### DIFF
--- a/src/Westsworld/TimeAgo/Language.php
+++ b/src/Westsworld/TimeAgo/Language.php
@@ -201,8 +201,8 @@ abstract class Language
             return false;
         };
 
-        return $timeDifference->i < 45 &&
-            $timeDifference->s < 30 &&
+        return ($timeDifference->i < 44 ||
+            ($timeDifference->i === 44 && $timeDifference->s < 30)) &&
             ! $this->isLessThan1Min29Seconds($timeDifference);
     }
 

--- a/tests/TimeagoTest.php
+++ b/tests/TimeagoTest.php
@@ -46,6 +46,7 @@ class TimeagoTest extends TestCase
 
         // testing 2..44 minutes
         $this->assertContains('minutes ago', $timeAgo->inWordsFromStrings("-2 minute"));
+        $this->assertContains('minutes ago', $timeAgo->inWordsFromStrings("-2 minute -40 second"));
         $this->assertContains('minutes ago', $timeAgo->inWordsFromStrings("-44 minute"));
         $this->assertContains('minutes ago', $timeAgo->inWordsFromStrings("-44 minute -29 second"));
         $this->assertNotContains('minutes ago', $timeAgo->inWordsFromStrings("-44 minute -30 second"));


### PR DESCRIPTION
When calculating time less than 44 minutes and 29 seconds the label sometimes wasn't correct. When the seconds were bigger than 29 the label "about 1 hour" was used even when the minutes were lower than 44.

This PR adds a fix for this issue and adds a test.

Fix for issue: #72 