### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: php
 
 dist: trusty
 php:
-  - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 before_script:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,16 @@
         }
     ],
     "require": {
-        "php": ">=5.6"
+        "php": "^7.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6",
+        "phpunit/phpunit": "^7",
         "phpmd/phpmd": "@stable",
         "squizlabs/php_codesniffer": "^3.3"
     },
     "autoload": {
-		"psr-0": {
-			"Westsworld": "src/"
+		"psr-4": {
+			"Westsworld\\": "src/Westsworld/"
 		}
     },
     "config": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,11 +10,7 @@
 
     <filter>
         <whitelist>
-            <directory suffix=".php">./</directory>
-            <exclude>
-                <directory suffix=".php">./vendor</directory>
-                <directory suffix=".php">./translations</directory>
-            </exclude>
+            <directory suffix=".php">./src/</directory>
         </whitelist>
     </filter>
 

--- a/src/Westsworld/TimeAgo.php
+++ b/src/Westsworld/TimeAgo.php
@@ -58,7 +58,7 @@ class TimeAgo
             return $this->language;
         }
 
-        $this->language = new \Westsworld\TimeAgo\Translations\En();
+        $this->language = new En();
 
         return $this->language;
     }

--- a/tests/TimeagoTest.php
+++ b/tests/TimeagoTest.php
@@ -2,6 +2,9 @@
 
 namespace Westsworld\TimeAgo\Tests;
 
+use Westsworld\TimeAgo\Translations\En;
+use Westsworld\TimeAgo\Translations\Da;
+use Westsworld\TimeAgo\Translations\De;
 use Westsworld\TimeAgo;
 use PHPUnit\Framework\TestCase;
 use DateTime;
@@ -14,6 +17,27 @@ use DateInterval;
  */
 class TimeagoTest extends TestCase
 {
+    public function testCreate()
+    {
+        $timeAgo = TimeAgo::create(new En());
+
+        $this->assertInstanceOf(TimeAgo::class, $timeAgo);
+    }
+
+    public function testDateDifference()
+    {
+        $timeAgo = TimeAgo::create(new En());
+        $past = new DateTime(date('2019-04-04'));
+        $result = $timeAgo->dateDifference($past);
+
+        $this->assertContains('years', $result);
+        $this->assertContains('months', $result);
+        $this->assertContains('days', $result);
+        $this->assertContains('hours', $result);
+        $this->assertContains('minutes', $result);
+        $this->assertContains('seconds', $result);
+    }
+
     public function testIsAlive()
     {
         $this->assertTrue(true);
@@ -42,7 +66,7 @@ class TimeagoTest extends TestCase
         $this->assertEquals('1 minute ago', $timeAgo->inWordsFromStrings("-60 second"));
         $this->assertEquals('1 minute ago', $timeAgo->inWordsFromStrings("-89 second"));
         $this->assertNotEquals('1 minute ago', $timeAgo->inWordsFromStrings("-90 second"));
-        
+
 
         // testing 2..44 minutes
         $this->assertContains('minutes ago', $timeAgo->inWordsFromStrings("-2 minute"));
@@ -109,8 +133,8 @@ class TimeagoTest extends TestCase
 
     public function testTimeAgoInWordsDateTime()
     {
-        $timeAgo = new TimeAgo(new \Westsworld\TimeAgo\Translations\En());
-        
+        $timeAgo = new TimeAgo(new En());
+
         // testing "less than a minute"
         $this->assertEquals('less than a minute ago', $timeAgo->inWords(new DateTime()));
         $this->assertEquals('less than a minute ago', $timeAgo->inWords((new DateTime())->sub(new DateInterval('PT1S'))));
@@ -124,18 +148,21 @@ class TimeagoTest extends TestCase
         $this->assertNotEquals('1 minute ago', $timeAgo->inWords((new DateTime())->sub(new DateInterval('PT90S'))));
     }
 
-    public function testLanguage()
+    public function languageDataProvider()
     {
-        // using default (english)
-        $timeAgo = new TimeAgo();
-        $this->assertEquals('less than a minute ago', $timeAgo->inWords(new DateTime()));
+        return [
+            [null, 'less than a minute ago', 'using default (english)'],
+            [new Da(), 'mindre end et minut siden', 'switching to danish', 'switching to danish'],
+            [new De(), 'vor weniger als einer Minute', 'switching to danish', 'switching to german'],
+        ];
+    }
 
-        // switching to danish
-        $timeAgo = new TimeAgo(new \Westsworld\TimeAgo\Translations\Da());
-        $this->assertEquals('mindre end et minut siden', $timeAgo->inWords(new DateTime()));
-
-        // switching to german
-        $timeAgo = new TimeAgo(new \Westsworld\TimeAgo\Translations\De());
-        $this->assertEquals('vor weniger als einer Minute', $timeAgo->inWords(new DateTime()));
+    /**
+     * @dataProvider languageDataProvider
+     */
+    public function testLanguage($language, $expected, $message)
+    {
+        $timeAgo = new TimeAgo($language);
+        $this->assertEquals($expected, $timeAgo->inWords(new DateTime()), $message);
     }
 }


### PR DESCRIPTION
# Changed log
- Using the `DataProvider` to collect the test cases for `testLanguage` test.
- Add the `create` and `dateDifference` method tests.
- Add the `php-7.3` test in Travis CI build.
- Drop `php-5.6` and `php-7.0` supports for this PHP package.
- Fix the white filter list in `phpunit.xml` setting.
- Using the `psr-4` autoloader because the `psr-0` autoloading is deprecated.