### PR TITLE
Remove three dots from "years" for TR language

### DIFF
--- a/src/Westsworld/TimeAgo/Translations/Tr.php
+++ b/src/Westsworld/TimeAgo/Translations/Tr.php
@@ -22,7 +22,7 @@ class Tr extends Language
             'lessThanOneHour' => "%s dakika önce",
             'months' => "%s ay önce",
             'oneMinute' => "1 dakika önce",
-            'years' => "%s yıldan fazla...",
+            'years' => "%s yıldan fazla",
             'never' => 'Asla'
         ]);
     }


### PR DESCRIPTION
I removed three dots from "years" for TR language, since it's not available in other languages