### PR TITLE
localized numbers in '%s' format

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,30 +1,35 @@
 {
-    "name": "jimmiw/php-time-ago",
-    "description": "Simple module, that displays the date in a \"time ago\" format",
-    "keywords": ["time ago", "distance of time", "time ago in words"],
-    "homepage": "https://github.com/jimmiw/php-time-ago",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Jimmi Westerberg",
-            "homepage": "http://www.westsworld.dk",
-            "role": "Developer"
-        }
-    ],
-    "require": {
-        "php": ">=7.0.0"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^6",
-        "phpmd/phpmd": "@stable",
-        "squizlabs/php_codesniffer": "^3.3"
-    },
-    "autoload": {
-		"psr-4": {
-			"Westsworld\\": "src/Westsworld/"
-		}
-    },
-    "config": {
-        "bin-dir": "vendor/bin/"
+  "name": "jimmiw/php-time-ago",
+  "description": "Simple module, that displays the date in a \"time ago\" format",
+  "keywords": [
+    "time ago",
+    "distance of time",
+    "time ago in words"
+  ],
+  "homepage": "https://github.com/jimmiw/php-time-ago",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Jimmi Westerberg",
+      "homepage": "http://www.westsworld.dk",
+      "role": "Developer"
     }
+  ],
+  "require": {
+    "php": ">=7.0.0",
+    "ext-intl": "*"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^6",
+    "phpmd/phpmd": "@stable",
+    "squizlabs/php_codesniffer": "^3.3"
+  },
+  "autoload": {
+    "psr-4": {
+      "Westsworld\\": "src/Westsworld/"
+    }
+  },
+  "config": {
+    "bin-dir": "vendor/bin/"
+  }
 }

--- a/src/Westsworld/TimeAgo/Language.php
+++ b/src/Westsworld/TimeAgo/Language.php
@@ -5,6 +5,8 @@ namespace Westsworld\TimeAgo;
 use DateInterval;
 use DateTime;
 use DateTimeInterface;
+use NumberFormatter;
+use ReflectionClass;
 
 abstract class Language
 {
@@ -397,6 +399,9 @@ abstract class Language
             return '';
         }
 
-        return sprintf($this->getTranslations()[$label], $time);
+        $localeName = (new ReflectionClass($this))->getShortName();
+        $numberFormatter = NumberFormatter::create($localeName, NumberFormatter::DEFAULT_STYLE);
+        $localizedTime = $numberFormatter->format($time) ?? $time;
+        return sprintf($this->getTranslations()[$label], $localizedTime);
     }
 }

--- a/src/Westsworld/TimeAgo/Translations/My.php
+++ b/src/Westsworld/TimeAgo/Translations/My.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Westsworld\TimeAgo\Translations;
+
+use \Westsworld\TimeAgo\Language;
+
+/**
+ * Myanmar translations
+ */
+class My extends Language
+{
+    public function __construct()
+    {
+        $this->setTranslations([
+            'aboutOneDay' => "၁ ရက် ခန့်က",
+            'aboutOneHour' => "၁ နာရီ ခန့်က",
+            'aboutOneMonth' => "၁ လ ခန့်က",
+            'aboutOneYear' => "၁ နှစ် ခန့်က",
+            'days' => "%s ရက် အကြာက",
+            'hours' => "%s နာရီ အကြာက",
+            'lessThanAMinute' => "ယခုလေးတင်",
+            'lessThanOneHour' => "%s မိနစ် အကြာက",
+            'months' => "%s လ အကြာက",
+            'oneMinute' => "တစ်မိနစ် အကြာက",
+            'years' => "%s နှစ် ကျော်က",
+            'never' => 'အချက်အလက် မရှိပါ'
+        ]);
+    }
+}


### PR DESCRIPTION
Some languages such as Burmese (Myanmar), Bengali (India) and Arabic (Egypt) etc.. have their own localized numbers.

| Language | Locale Code | English Numbers | Localized Numbers |
| ------------- | ------------- | ------------- | ------------- |
| Burmese | my (or) my_MM | 1234567890 | ၁၂၃၄၅၆၇၈၉၀ |
| Bengali (India) | bn_IN | 1234567890 | ১২৩৪৫৬৭৮৯০ |
| Arabic (Egypt) | ar_EG | 1234567890 | ١٢٣٤٥٦٧٨٩٠ |

So we can use ```NumberFormatter``` class to localize time numbers.

There are 2 requirements to localize numbers.
- ```NumberFormatter``` class needs ```ext-intl``` php extension.
- Translation script names such as ```My.php```, ```En.php``` must be locale code names because ```NumberFormatter``` needs locale name to create its instance.

```php
$localeName = (new ReflectionClass($this))->getShortName();
$numberFormatter = NumberFormatter::create($localeName, NumberFormatter::DEFAULT_STYLE);
$localizedTime = $numberFormatter->format($time) ?? $time;
```

### sample
```php
$myLang = new \Westsworld\TimeAgo\Translations\My();
$timeAgo = new Westsworld\TimeAgo($myLang);
echo $timeAgo->inWords(new DateTime('-10 minutes'));
```

Result will be ```၁၀ မိနစ် အကြာက ✅``` instead of ```10 မိနစ် အကြာက ❌```.


